### PR TITLE
Add X-Forwarded-For to IP page and use JSON

### DIFF
--- a/files/index.php
+++ b/files/index.php
@@ -1,0 +1,14 @@
+<?php
+
+header("Content-Type: application/json");
+
+$ips = [
+  'my_ip' => gethostbyname(trim(`hostname`)),
+  'your_ip' => $_SERVER['REMOTE_ADDR']
+];
+
+if ($_SERVER['HTTP_X_FORWARDED_FOR'] && filter_var($_SERVER['HTTP_X_FORWARDED_FOR'], FILTER_VALIDATE_IP)) {
+  $ips['forwarded_for'] = $_SERVER['HTTP_X_FORWARDED_FOR'];
+}
+
+echo json_encode($ips, JSON_PRETTY_PRINT);


### PR DESCRIPTION
When used behind an AWS Application Load Balancer, this addition will allow the page to show the client's IP address behind the load balancer, since `$_SERVER['REMOTE_ADDR']` will only show the address of the load balancer itself.

Additionally, this will convert the output to pretty-printed JSON, so it can easily be read by both humans and machines.

The provisioner script and/or the Packer file will need to be updated to reflect this change.